### PR TITLE
fix python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent"
         ],
-    python_requires='>=3.7'
+    python_requires='>=3.9'
 )


### PR DESCRIPTION
[docs](https://github.com/hegelty/pycomcigan/blob/master/docs.md)에서 파이썬 버전은 3.9 이상이 필요하다고 되어있습니다.
하지만, setup.py는 파이썬 3.7 이상이라고 되어 있습니다.
이 pr은 setup.py의 파이썬 버전 부분을 3.7 이상에서 3.9 이상으로 변경하였습니다.